### PR TITLE
added config options for nvp

### DIFF
--- a/src/Cygnus/DrushExport/ExportD6.php
+++ b/src/Cygnus/DrushExport/ExportD6.php
@@ -59,7 +59,30 @@ class ExportD6 extends Export
             ],
             'database'          => 'import_mni_tampabay',
             'host'              => 'tampabaymedicalnews.com'
+        ],
+        'nashvillepost'      => [
+            'Taxonomy'  => [
+                'Companies'         => 'Taxonomy\\Organization', // no company, use organization or override?
+                'County'            => 'Taxonomy\\Region'  // Location data but much more specific than locations data - use in region or put into Location with other data?
+                'Locations'         => 'Taxonomy\\Location',
+                'Main'              => 'Taxonomy\\Category', // category or topic?
+                'People'            => 'Taxonomy\\Person',
+                'Subjects'          => 'Taxonomy\\Tag',  // topic or tag?
+                'Tags'              => 'Taxonomy\\Tag'
+            ],
+            'Content'   => [
+                'article'       => 'Website\\Content\\Article',
+                'blog'          => 'Website\\Content\\Blog',
+                'gallery'       => 'Website\\Content\\MediaGallery',
+                'need_to_know'  => 'Website\\Content\\Article',
+            ],
+            'Section'   => [
+                'callout'          => 'Website\\Section',
+            ],
+            'database'          => 'import_nvp',
+            'host'              => 'nashvillepost.com'
         ]
+
     ];
 
     /**

--- a/src/Cygnus/DrushExport/ExportD6.php
+++ b/src/Cygnus/DrushExport/ExportD6.php
@@ -63,7 +63,7 @@ class ExportD6 extends Export
         'nashvillepost'      => [
             'Taxonomy'  => [
                 'Companies'         => 'Taxonomy\\Organization', // no company, use organization or override?
-                'County'            => 'Taxonomy\\Region'  // Location data but much more specific than locations data - use in region or put into Location with other data?
+                'County'            => 'Taxonomy\\Region',  // Location data but much more specific than locations data - use in region or put into Location with other data?
                 'Locations'         => 'Taxonomy\\Location',
                 'Main'              => 'Taxonomy\\Category', // category or topic?
                 'People'            => 'Taxonomy\\Person',

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'phar://export.phar/Cygnus/DrushExport/AbstractExport.php';
 require_once 'phar://export.phar/Cygnus/DrushExport/ExportD6.php';
+require_once 'phar://export.phar/Cygnus/DrushExport/ExportNVP.php';
 require_once 'phar://export.phar/Cygnus/DrushExport/ExportD7.php';
 
 define('DRUPAL_VERSION', drush_core_status('drupal-version')['drupal-version']);
@@ -26,6 +27,9 @@ if (!isset($argv[6])) {
     exit(1);
 }
 $key = $argv[6];
+if ('nashvillepost' == $key) {
+    $class = 'cygnus\\DrushExport\\ExportNVP';
+}
 
 
 $export = new $class($key, $dsn);


### PR DESCRIPTION
node_type  -- article, blog, callout, county, gallery_image, gallery, image, need_to_know, sidebar, static, webform
vocabulary -- Main, Companies, Locations, tags, People, Subjects, Image Galleries, County

node_type
callout: 20 items - Legal, Health Care, Development, Politics, Finance, Technology, Education, Retail - taxonomy, section?
county: 2 items - COUNTY COVERAGE, County Coverage - useless?
gallery: 76 items - self explanatory
gallery_image: 969 items - single images
image: 2 items - looks like gallery_image is all that was used (and gallery)
need_to_know: 29 items - looks like a special series of articles - article or blog?
sidebar: 0 items
static: 25 items - statick pages, about us, advertising info, free trial info, special award/cover, privacy statement, etc
webform: 3 items - Entrepeneur of the year 2012, Entrepreneur of the year RSVP, Nahsville Post VIP Introduction

vocabulary
Main: 22 items - Area Stocks, Education, Finance, Health Care, Legal, Manufacturing, Retail, The Goods, The Record, Tourism, etc - has to be category or topic
Locations: 1039 items - mix of street addresses, states, regions (airport north), city/state, country, etc
Tags: 15935 items
Subjects: 2278 items - thought would be topic but seems to data looks too freeform, perhaps also tag?
      predators-sharks, predators-stars, predators-wild, predatory lending, prediction markets, predictive modeling software, prescription assistence, prescrption drugs, preseason baseball...
Image Galliers - no terms defined for vocab - dropping
County: 6 items - map to location, or region?  (Maury, Montgombery, Rutehrford, Sumner, Williamson, Wilson)
